### PR TITLE
python3-yamlを用いてroutines.yamlをパースするよう変更

### DIFF
--- a/routines.yaml
+++ b/routines.yaml
@@ -1,5 +1,5 @@
 # timezone: utc
-- name: 'melatonin'
+- name: melatonin
   onCalendar: '*-*-* 12:00'
-- name: 'sleep-preparation'
+- name: sleep-preparation
   onCalendar: '*-*-* 13:00'

--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -42,14 +42,12 @@ function main() {
   local systemd_dir="/etc/systemd/system"
 
   local routines_yaml="$(cat routines.yaml)"
-  local name_lines=$(grep 'name:' <<< "$routines_yaml")
-  local onCalendar_lines=$(grep 'onCalendar: ' <<< "$routines_yaml")
-  local len=$(wc -l <<< "$name_lines")
+  local len=$(python3 -c 'import sys, yaml; y=yaml.safe_load(sys.stdin.read()); print(len(y))' <<< "$routines_yaml")
 
   [[ $len -le 0 ]] && return 0
   for i in $( seq 0 $((len - 1)) ); do
-    local name=$(awk -v i=$i 'NR==i+1' <<< "$name_lines" | sed -ne "s;- name: '\(.*\)';\1;p")
-    local onCalendar=$(awk -v i=$i 'NR==i+1' <<< "$onCalendar_lines" | sed -ne "s;  onCalendar: '\(.*\)';\1;p")
+    local name=$(python3 -c "import sys, yaml; y=yaml.safe_load(sys.stdin.read()); print(y[$i]['name'])" <<< "$routines_yaml")
+    local onCalendar=$(python3 -c "import sys, yaml; y=yaml.safe_load(sys.stdin.read()); print(y[$i]['onCalendar'])" <<< "$routines_yaml")
 
     generate_service "$name" "$systemd_dir"
     sudo systemctl enable ${PREFIX}${name}.service

--- a/scripts/uninstall.bash
+++ b/scripts/uninstall.bash
@@ -6,12 +6,11 @@ function main() {
   local systemd_dir="/etc/systemd/system"
 
   local routines_yaml="$(cat routines.yaml)"
-  local name_lines=$(grep 'name:' <<< "$routines_yaml")
-  local len=$(wc -l <<< "$name_lines")
+  local len=$(python3 -c 'import sys, yaml; y=yaml.safe_load(sys.stdin.read()); print(len(y))' <<< "$routines_yaml")
 
   [[ $len -le 0 ]] && return 0
   for i in $( seq 0 $((len - 1)) ); do
-    local name=$(awk -v i=$i 'NR==i+1' <<< "$name_lines" | sed -ne "s;- name: '\(.*\)';\1;p")
+    local name=$(python3 -c "import sys, yaml; y=yaml.safe_load(sys.stdin.read()); print(y[$i]['name'])" <<< "$routines_yaml")
 
     sudo systemctl disable ${PREFIX}${name}.service
     sudo rm -f ${systemd_dir}/${PREFIX}${name}.service


### PR DESCRIPTION
this fixes #1 .

sedを使った簡易yamlパースを行っていたため、validなyamlでも受け付けない場合があった。
それを修正する。